### PR TITLE
bug fix for working directory indented incorrectly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,16 +26,11 @@ jobs:
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
-        working-directory: ./polaris
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
-          cache-paths: |
-            build.gradle.kts
-            settings.gradle.kts
-            gradle.properties
-            gradle/wrapper/gradle-wrapper.properties
+          working-directory: ./polaris
       
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3


### PR DESCRIPTION
Bug fix for [Invalid workflow file: .github/workflows/build.yml#L29](https://github.com/krishnasai-sistla-get2know/polaris/actions/runs/14572847572/workflow)
The workflow is not valid. .github/workflows/build.yml (Line: 29, Col: 9): Unexpected value 'working-directory'