### PR TITLE
keep only the most recent package version and delete the rest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
       packages: write
       id-token: write # Needed for attestation
+      actions: read   # Required for attestation
     
     steps:
       - name: Clone Apache Polaris repository
@@ -105,3 +106,11 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Delete older package versions
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: 'polaris'
+          package-type: 'container'
+          min-versions-to-keep: 1 # Keep only the most recent version
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Workaround Github free tier package limit of 500MB

Potential bug fix for [build-and-push](https://github.com/krishnasai-sistla-get2know/polaris/actions/runs/14572947776/job/40873364839#step:12:126)
Error: Failed to persist attestation: Resource not accessible by integration - https://docs.github.com/rest/repos/repos#create-an-attestation