### PR TITLE
Update build.yml to retain 3 most recent versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           VERSION=${{ steps.polaris-version.outputs.version }}
           DIGEST=$(docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION} | grep digest | awk '{print $3}')
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          docker push --all-tags ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "Pushed image with digest: $DIGEST"
@@ -113,7 +113,7 @@ jobs:
         with:
           package-name: 'polaris'
           package-type: 'container'
-          min-versions-to-keep: 1 # Keep only the most recent version
+          min-versions-to-keep: 3 # Keep only the most 3 recent version
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if release exists


### PR DESCRIPTION
Fix for docker 
`pull ghcr.io/krishnasai-sistla-get2know/polaris:sha256-bc93b41cffe6d8fc945827fd4f65aaa1b1e7a95db986ae5bfb6d3614edb2d766`

`sha256-bc93b41cffe6d8fc945827fd4f65aaa1b1e7a95db986ae5bfb6d3614edb2d766: Pulling from krishnasai-sistla-get2know/polaris`

`manifest unknown`